### PR TITLE
Use currently running executable to run the analyser script.

### DIFF
--- a/beetsplug/bpmanalyser/command.py
+++ b/beetsplug/bpmanalyser/command.py
@@ -9,6 +9,7 @@ import os
 from concurrent import futures
 from optparse import OptionParser
 from subprocess import Popen, PIPE
+import sys
 
 from beets.library import Library as BeatsLibrary
 from beets.ui import Subcommand, decargs
@@ -146,7 +147,7 @@ class BpmAnayserCommand(Subcommand):
     def get_bpm_from_analyser_script(self, item_path):
         log.debug("calling external script: {}".format(self.analyser_script_path))
 
-        proc = Popen(['python', self.analyser_script_path, item_path], stdout=PIPE, stderr=PIPE)
+        proc = Popen([sys.executable, self.analyser_script_path, item_path], stdout=PIPE, stderr=PIPE)
         stdout, stderr = proc.communicate()
 
         log.debug("External script error output: {}".format(stderr.decode("utf-8")))


### PR DESCRIPTION
This fixes #4, when `python` isn't the same version of Python that is currently being used with `beets`.